### PR TITLE
Remove the better-rolltables dependency for compatibilty with FoundryVTT 0.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Roll tables and plants are included as compendiums. Open up the roll table and s
 * Paste the following link into the "Manifest URL" field at the bottom: https://github.com/KyleBishop/FoundryVTT-FantasyPlants/releases/download/1.0.0/module.json
 * Click Install
 
+**Foundry 0.7.x:**
+* Install the "Better Rolltables" module
+
 
 # Suggested Use #
 I currently use this in my campaign to allow players to forage. If you use the included roll tables for the region(s) they are in, you can select the Generate Loot button on the table, it will create a new instance of the item on the Actor "Found Plants" in the Actors tab (it will create that loot actor if you don't have it already). 

--- a/fantasy-plants-compendium/module.json
+++ b/fantasy-plants-compendium/module.json
@@ -5,7 +5,7 @@
    "author": "iHaveReturnd",
    "version": "1.0.0",
    "minimumCoreVersion": "0.7.0",
-   "compatibleCoreVersion":"0.7.9",
+   "compatibleCoreVersion":"0.8.6",
    "packs": [
     {
       "name": "plants",
@@ -23,10 +23,6 @@
     }
   ],
   "dependencies": [
-	{
-	  "name": "better-rolltables",
-	  "manifest": "https://raw.githubusercontent.com/ultrakorne/better-rolltables/master/module.json"
-	},
 	{
       "name": "lootsheetnpc5e",
       "manifest": "https://raw.githubusercontent.com/jopeek/fvtt-loot-sheet-npc-5e/master/module.json"


### PR DESCRIPTION
Better Rolltables seems to be abandoned and is incompatible with the 0.8.x version.